### PR TITLE
fix: block page scroll by active burger menu

### DIFF
--- a/src/Components/Header/Header.module.scss
+++ b/src/Components/Header/Header.module.scss
@@ -26,6 +26,7 @@
       stroke: $color-primary;
     }
     @media screen and (max-width: $break-lg) {
+      background-color: $color-primary;
       .main-menu {
         color: unset;
       }
@@ -33,6 +34,10 @@
         stroke: $color-neutral-light;
       }
     }
+  }
+
+  @media screen and (max-width: $break-lm) {
+    position: fixed;
   }
 
   @media screen and (max-width: $break-sm) {

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react'
+import { useState, useContext, useEffect } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import CurrentUserContext from '@/contexts/CurrentUserContext'
 import s from './Header.module.scss'
@@ -16,6 +16,10 @@ export default function Header(props: HeaderProps) {
 
   const isTransparent = () =>
     location.pathname === '/register' || location.pathname === '/login'
+
+  useEffect(() => {
+    document.body.style.overflow = burgerActive ? 'hidden' : 'unset'
+  }, [burgerActive])
 
   return (
     <header
@@ -94,7 +98,9 @@ export default function Header(props: HeaderProps) {
       <button
         type="button"
         className={!burgerActive ? s.burger : `${s.burger} ${s.active}`}
-        onClick={() => setBurgerActive(!burgerActive)}
+        onClick={() => {
+          setBurgerActive(!burgerActive)
+        }}
       >
         <span />
       </button>


### PR DESCRIPTION
## Task

[eCommerce-Application](https://github.com/rolling-scopes-school/tasks/tree/master/tasks/eCommerce-Application)

## Related task item

none

## Description

This PR fixes scroll of the page by opened burger menu, which didn't look good. Now the header has position: fixed for small screens (with burger) and page scroll blocks by opening burger menu.

## What type of PR is this? (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Build
- [ ] Other

## Screenshot

Before:
![image](https://github.com/NikolayKrishtopa/eCommerce-Application/assets/116670798/1834daa0-ae9c-49d1-be9b-09d5e3aec2a5)

After:
![image](https://github.com/NikolayKrishtopa/eCommerce-Application/assets/116670798/74e54129-79ff-4f51-aeac-d9704ced31c2)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] README.md
- [x] no documentation needed
